### PR TITLE
Use Dynamic Imports for shoelace/fluent-ui

### DIFF
--- a/Template/WebLit/src/Utils.fs
+++ b/Template/WebLit/src/Utils.fs
@@ -3,6 +3,7 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Core.DynamicExtensions
 open Browser.Types
+open Lit
 
 [<AutoOpen>]
 module PromiseExtensions =
@@ -45,6 +46,23 @@ let private registerShoelace() =
 let registerComponents () = 
     registerFluentUI()
     registerShoelace()
+
+[<LitElement("bs-icon")>]
+let BootstrapIcon() = 
+    let _, props =
+        LitElement.init(fun init ->
+            init.useShadowDom <- false
+            init.props <- 
+                {| 
+                    src = Prop.Of(defaultValue = "SurveyQuestions", attribute = "src")
+                    size = Prop.Of(defaultValue = "20px", attribute = "size")
+                    color = Prop.Of(defaultValue = "#036ac4", attribute = "color")
+                |}
+        )
+
+    html $"""
+        <i class="bi bi-{props.src.Value}" style="font-size: {props.size.Value}; color: {props.color.Value};"></i>
+    """
 
 /// Grapnel Router bindings.
 module Grapnel =


### PR DESCRIPTION
When you use `importSideEffects` even inside a function Fable emits an import on the top of the file this makes the import static and adds to the main bundle
thanfully for shoelace/fluent-ui we don't need to do that and can import them dynamically
that will reduce main bundle size and should not impact negatively in any way

![image](https://user-images.githubusercontent.com/8684875/172033576-7574b0eb-63fa-4555-916f-d5928df1fec3.png)


![image](https://user-images.githubusercontent.com/8684875/172033569-bcfa29ed-b2a3-40f5-8004-f48ac3304515.png)

Feel free to close this if not necessary
